### PR TITLE
fix(iverilog): remove static from tb

### DIFF
--- a/tb/busmnt.v
+++ b/tb/busmnt.v
@@ -24,7 +24,12 @@ wire    [31:0]  ahb_xx_hwdata;
 wire            ahb_xx_hwrite;  
 wire            sysrst_b;    
 wire            sysclk;         
-static integer FILE;
+
+`ifdef iverilog
+  integer FILE;
+`else
+  static integer FILE;
+`endif
 
 `define CPU_TOP wujian100_open_tb.x_wujian100_open_top.x_cpu_top
 

--- a/tb/tb.v
+++ b/tb/tb.v
@@ -25,7 +25,13 @@ module wujian100_open_tb ();
 `define CLKMUX_EHS_CLK_DURATION 25 
 
 `define CLKMUX_ELS_CLK_DURATION 15258.789
-static integer FILE;
+
+`ifdef iverilog
+  integer FILE;
+`else
+  static integer FILE;
+`endif
+
 reg     [31:0]  cpuclk_counter;           
 reg             i_ext_pad_clkmux_ehs_clk; 
 reg             i_ext_pad_clkmux_els_clk; 


### PR DESCRIPTION
解决通过 iverilog 编译时，报
```
../tb/busmnt.v:27: syntax error
../tb/busmnt.v:27: error: Invalid module instantiation
```
的问题，但是由于没有 vcs 开发环境，是否会对 vcs 造成影响暂无法验证，合并前需要在 vcs 上验证。